### PR TITLE
added Hide Behind Interfaces toggle, allowing bars to appear when at …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,3 @@ targetCompatibility = '11'
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
-
-def pluginMainClass = 'RastaXP.PluginLauncher'
-
-tasks.register('run', JavaExec) {
-	classpath = sourceSets.test.runtimeClasspath
-	mainClass = pluginMainClass
-	jvmArgs "-ea"
-	args "--developer-mode", "--debug"
-}

--- a/build.gradle
+++ b/build.gradle
@@ -31,3 +31,12 @@ targetCompatibility = '11'
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
 }
+
+def pluginMainClass = 'RastaXP.PluginLauncher'
+
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = pluginMainClass
+	jvmArgs "-ea"
+	args "--developer-mode", "--debug"
+}

--- a/src/main/java/RHUD/RHUD_Config.java
+++ b/src/main/java/RHUD/RHUD_Config.java
@@ -534,4 +534,13 @@ public interface RHUD_Config extends Config {
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		position = 36,
+		keyName = "hideInterfaces",
+		name = "Hide Behind Interfaces",
+		description = "Hides the bars while the bank interface is open.",
+		section = statusSection
+	)
+	default boolean hideInInterfaces() { return false; }
 }

--- a/src/main/java/RHUD/RHUD_Plugin.java
+++ b/src/main/java/RHUD/RHUD_Plugin.java
@@ -34,6 +34,7 @@ import lombok.Getter;
 import net.runelite.api.*;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.SkillIconManager;
@@ -409,11 +410,13 @@ class HUD extends OverlayPanel {
 
 	@Override
 	public Dimension render(Graphics2D g) {
+		if (config.hideInInterfaces() && isBlockingInterfaceOpen()) {
+			return null;
+		}
 		Dimension dimension = null;
-		Widget bankContainer = client.getWidget(ComponentID.BANK_ITEM_CONTAINER);
+		final boolean hide = config.hideInInterfaces() && isBlockingInterfaceOpen();
 
-
-		if (bankContainer == null || bankContainer.isHidden()) {
+		if (!hide) {
 			int width = config.barWidth(), adjX = config.barOffsetX();
 			int adjY = config.barOffsetY();
 			int totalHeight = 0;
@@ -934,6 +937,21 @@ class HUD extends OverlayPanel {
 
 	private boolean inLms() {
 		return client.getWidget(ComponentID.LMS_INGAME_INFO) != null;
+	}
+	private static final int[] BLOCKING_GROUPS = {
+			InterfaceID.BANK,
+			InterfaceID.DEPOSIT_BOX,
+			InterfaceID.GRAND_EXCHANGE,
+	};
+
+	private boolean isBlockingInterfaceOpen() {
+		for (final int group : BLOCKING_GROUPS) {
+			final Widget root = client.getWidget(group, 0);
+			if (root != null && !root.isHidden()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private int getRestoreValue(String skill) {


### PR DESCRIPTION
## Problem

`HUD.render()` wraps its entire body in a bank-widget check, so when the bank
interface is open nothing draws and the method returns `null`. This also
accounts for the Grand Exchange reports.

## Change

- Converted the guard from a body-wrapping `if` to an early return.
- Extracted it into `isBlockingInterfaceOpen()`, covering [interfaces].
- Added a `Hide Behind Interfaces` config item under Status Options.

Defaults to **false**, so the bars now stay visible at the bank. Setting it to
true restores the previous behaviour. Overlay layer unchanged.

## Testing

Bank booth, bank chest, deposit box, GE booth, collection
box; option on and off; fixed and resizable; all three layouts; all bars
disabled. No exceptions in client.log.

Fixes https://github.com/Beardedrasta/RHUD/issues/15